### PR TITLE
Fix webpack failing to init for anyone without Ultra

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -11,7 +11,7 @@ if (fs.existsSync(preloadPath)) {
     
     let renderer = fs.readFileSync(rendererPath, "utf8");
 
-    if (fs.existsSync(__dirname, "..", "ultra")) {
+    if (fs.existsSync(path.resolve(__dirname, "..", "ultra"))) {
         renderer = renderer.replace(/(WebpackInterceptor[\s\S]+Object\.defineProperty\(window),\s?[\w]+,/, `$1, "\\$\\$VENCORD_WEBPACK_SPOOF",`);
     }
 


### PR DESCRIPTION
This is because it would replace a patch on window.webpackChunkdiscord_app with a patch on window.\$\$VENCORD_WEBPACK_SPOOF. Missing path.combine on the check is all it is.